### PR TITLE
docs: fix parameters typo

### DIFF
--- a/LLM_PROMPT.md
+++ b/LLM_PROMPT.md
@@ -6,7 +6,7 @@ Mejora el prompt que sera enviado a un LLM:
 ```
 
 ```
-Explain how to choose the following paramters.
+Explain how to choose the following parameters.
 ```
 
 ```


### PR DESCRIPTION
## Problem
`LLM_PROMPT.md` contains a visible typo: `paramters`.

## Solution
Corrected it to `parameters`.

## Validation
- `git diff --check`

Confidence score: 85/100
Category: docs/typo
